### PR TITLE
fix: Bilder werden nicht geladen (ILENE-56)

### DIFF
--- a/backend/app/Http/Controllers/PhpinfoController.php
+++ b/backend/app/Http/Controllers/PhpinfoController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use Dedoc\Scramble\Attributes\ExcludeAllRoutesFromDocs;
 use Illuminate\Http\Request;
 
+#[ExcludeAllRoutesFromDocs]
 class PhpinfoController extends Controller
 {
     /**

--- a/backend/app/Http/Controllers/StorageController.php
+++ b/backend/app/Http/Controllers/StorageController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Attachment;
+use Dedoc\Scramble\Attributes\ExcludeAllRoutesFromDocs;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
+#[ExcludeAllRoutesFromDocs]
 class StorageController extends Controller
 {
     /**

--- a/frontend/buildSrc/make-config.js
+++ b/frontend/buildSrc/make-config.js
@@ -1,0 +1,18 @@
+/**
+ * @param {import("next").NextConfig} original
+ */
+export default function makeConfig(original) {
+    const copy = Object.assign({}, original)
+
+    const apiUrl = new URL(process.env.API_URL)
+    copy.images.remotePatterns = [
+        {
+            protocol: apiUrl.protocol.substring(0, 4),
+            hostname: apiUrl.hostname,
+            port: apiUrl.port,
+            pathname: '/storage/**',
+        },
+    ]
+
+    return copy
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -13,7 +13,6 @@ const nextConfig = {
                 port: '8000',
                 pathname: '/storage/**',
             },
-
         ],
     },
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && bun ./scripts/modify-config.ts",
     "start": "next start",
     "lint": "eslint",
     "postinstall": "./gen-api-client.sh"

--- a/frontend/scripts/modify-config.ts
+++ b/frontend/scripts/modify-config.ts
@@ -1,0 +1,42 @@
+import { log } from 'node:console'
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+const fileSource = '.next/standalone/server.js'
+const fileBackup = `${fileSource}.bak`
+if (!existsSync(fileBackup)) {
+    cpSync(fileSource, fileBackup)
+}
+
+const contents = readFileSync(fileBackup)
+const input = contents.toString('utf-8')
+const lines = input.split('\n')
+
+// add import
+let lastImportLine = 0
+for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.startsWith('import')) {
+        lastImportLine = i
+        continue
+    }
+}
+lines.splice(lastImportLine + 1, 0, 'import makeConfig from \'./make-config.js\'')
+
+// modify config statement
+let configLine = 0
+for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.startsWith('const nextConfig')) {
+        configLine = i
+        continue
+    }
+}
+
+const config = /(?:const\s+nextConfig\s*=\s*)(?<config>.*)/gm.exec(lines[configLine])
+lines[configLine] = `const nextConfig = makeConfig(${config?.groups?.config})`
+
+writeFileSync(fileSource, lines.join('\n'))
+log(' >> Modified Next.js default server.js')
+
+cpSync('buildSrc/make-config.js', '.next/standalone/make-config.js', { force: true })
+log(' >> Installed config modification script')

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,5 +28,9 @@
         ".next/types/**/*.ts",
         "global.d.ts"
     ],
-    "exclude": ["node_modules"]
+    "exclude": [
+        "node_modules",
+        "buildSrc",
+        "scripts"
+    ]
 }


### PR DESCRIPTION
Behebt das Problem, dass Bilder im Docker Deployment nicht geladen werden können, da als Remote Pattern für Bilder standardmäßig nur localhost konfiguriert ist und es von Haus aus keine Möglichkeit gibt, diese Werte zur Laufzeit zu setzen.

Daher wird ein kleines Skript zur Build Time injiziert, welches die Next.js Config dynamisch überschreibt.

Das Image Pattern wird aus der Umgebungsvariable `API_URL` extrahiert.