### PR TITLE
feat: add back buttons (ILENE-69)

### DIFF
--- a/frontend/src/app/(shell)/events/[id]/page.tsx
+++ b/frontend/src/app/(shell)/events/[id]/page.tsx
@@ -1,6 +1,9 @@
 import {EventDetails} from '@/features/posts/components/EventDetails'
 import {eventApi} from '@/lib/api/api'
 import {Alert, AlertTitle} from '@/lib/components/common/Alert'
+import { Button } from '@/lib/components/common/Button'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
 
 interface EventDetailPageProps {
     params: {
@@ -12,7 +15,23 @@ const EventDetailPage = async ({params}: EventDetailPageProps) => {
         const event = await eventApi.eventShow({id: params.id})
         const attachments = await eventApi.eventUploadList({id: event.id, type: 'attachment'})
         return (
-            <EventDetails event={{...event, attachments}} />
+            <div className='mx-auto h-full max-w-[800px]'>
+                <Button
+                    asChild
+                    size="sm"
+                    variant="link"
+                    className='mb-4'
+                >
+                    <Link href="/news">
+                        <ArrowLeft />
+                        <span className="ml-1">
+                            Zurück zu allen Veranstaltungen
+                        </span>
+                    </Link>
+                </Button>
+
+                <EventDetails event={{...event, attachments}} />
+            </div>
         )
     } catch (error) {
         console.error(error)

--- a/frontend/src/app/(shell)/events/[id]/page.tsx
+++ b/frontend/src/app/(shell)/events/[id]/page.tsx
@@ -1,9 +1,7 @@
 import {EventDetails} from '@/features/posts/components/EventDetails'
 import {eventApi} from '@/lib/api/api'
 import {Alert, AlertTitle} from '@/lib/components/common/Alert'
-import { Button } from '@/lib/components/common/Button'
-import { ArrowLeft } from 'lucide-react'
-import Link from 'next/link'
+import {BackButton} from '@/shared/components/BackButton'
 
 interface EventDetailPageProps {
     params: {
@@ -15,23 +13,12 @@ const EventDetailPage = async ({params}: EventDetailPageProps) => {
         const event = await eventApi.eventShow({id: params.id})
         const attachments = await eventApi.eventUploadList({id: event.id, type: 'attachment'})
         return (
-            <div className='mx-auto h-full max-w-[800px]'>
-                <Button
-                    asChild
-                    size="sm"
-                    variant="link"
-                    className='mb-4'
-                >
-                    <Link href="/news">
-                        <ArrowLeft />
-                        <span className="ml-1">
-                            Zurück zu allen Veranstaltungen
-                        </span>
-                    </Link>
-                </Button>
-
-                <EventDetails event={{...event, attachments}} />
-            </div>
+            <>
+                <BackButton href={'/events'}>Zur Veranstaltungen-Übersicht</BackButton>
+                <div className='mx-auto h-full max-w-[800px]'>
+                    <EventDetails event={{...event, attachments}} />
+                </div>
+            </>
         )
     } catch (error) {
         console.error(error)

--- a/frontend/src/app/(shell)/events/[id]/page.tsx
+++ b/frontend/src/app/(shell)/events/[id]/page.tsx
@@ -15,9 +15,7 @@ const EventDetailPage = async ({params}: EventDetailPageProps) => {
         return (
             <>
                 <BackButton href={'/events'}>Zur Veranstaltungen-Übersicht</BackButton>
-                <div className='mx-auto h-full max-w-[800px]'>
-                    <EventDetails event={{...event, attachments}} />
-                </div>
+                <EventDetails event={{...event, attachments}} />
             </>
         )
     } catch (error) {

--- a/frontend/src/app/(shell)/manage/canteen/dishes/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/canteen/dishes/[id]/page.tsx
@@ -1,5 +1,6 @@
 import MealEditor from '@/features/canteen/components/ManageMeal/MealEditor'
-import { canteenApi } from '@/lib/api/api'
+import {canteenApi} from '@/lib/api/api'
+import {BackButton} from '@/shared/components/BackButton'
 
 interface Props {
     params: {
@@ -9,9 +10,12 @@ interface Props {
 
 const ManageMealPage = async (props: Props) => {
     const meal = await canteenApi.dishShow({dish: parseInt(props.params.id)})
-    
+
     return (
-        <MealEditor meal={meal}/>
+        <>
+            <BackButton href={'/manage/canteen/dishes'}>Zur Gerichteübersicht</BackButton>
+            <MealEditor meal={meal} />
+        </>
     )
 }
 

--- a/frontend/src/app/(shell)/manage/canteen/dishes/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/canteen/dishes/[id]/page.tsx
@@ -13,7 +13,7 @@ const ManageMealPage = async (props: Props) => {
 
     return (
         <>
-            <BackButton href={'/manage/canteen/dishes'}>Zur Gerichteübersicht</BackButton>
+            <BackButton href={'/manage/canteen/dishes'}>Zur Gerichte-Übersicht</BackButton>
             <MealEditor meal={meal} />
         </>
     )

--- a/frontend/src/app/(shell)/manage/canteen/menus/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/canteen/menus/[id]/page.tsx
@@ -13,7 +13,7 @@ const ManageMenuPage = async ({params}: ManageMenuPageProps) => {
 
     return (
         <>
-            <BackButton href={'/manage/canteen/menus'}>Zur Menü-Übersicht</BackButton>
+            <BackButton href={'/manage/canteen/menus'}>Zur Menüs-Übersicht</BackButton>
             <ManageMenu menu={menu} />
         </>
     )

--- a/frontend/src/app/(shell)/manage/canteen/menus/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/canteen/menus/[id]/page.tsx
@@ -1,5 +1,6 @@
 import {ManageMenu} from '@/features/canteen/components/ManageMenu'
 import {canteenApi} from '@/lib/api/api'
+import {BackButton} from '@/shared/components/BackButton'
 
 interface ManageMenuPageProps {
     params: {
@@ -11,7 +12,10 @@ const ManageMenuPage = async ({params}: ManageMenuPageProps) => {
     const menu = await canteenApi.menuShow({menu: params.id})
 
     return (
-        <ManageMenu menu={menu} />
+        <>
+            <BackButton href={'/manage/canteen/menus'}>Zur Menü-Übersicht</BackButton>
+            <ManageMenu menu={menu} />
+        </>
     )
 }
 

--- a/frontend/src/app/(shell)/manage/events/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/events/[id]/page.tsx
@@ -1,8 +1,6 @@
 import {EditEvent} from '@/features/posts/components/EditEvent'
 import {eventApi} from '@/lib/api/api'
-import { Button } from '@/lib/components/common/Button'
-import { ArrowLeft } from 'lucide-react'
-import Link from 'next/link'
+import {BackButton} from '@/shared/components/BackButton'
 
 interface EditEventPageProps {
     params: {
@@ -15,26 +13,19 @@ const EditEventPage = async ({ params }: EditEventPageProps) => {
     const files = await eventApi.eventUploadList({ id: params.id })
     const attachments = files.filter((file) => file.type === 'attachment')
 
-    return (<>
-        <Button
-            asChild
-            size="sm"
-            variant="link"
-        >
-            <Link href="/manage/events">
-                <ArrowLeft />
-                <span className="ml-1">
-                    Zurück zu allen Veranstaltungen
-                </span>
-            </Link>
-        </Button>
-        <EditEvent
-            event={{
-                ...event,
-                attachments,
-            }}
-        />
-    </>)
+    return (
+        <>
+            <BackButton href={'/manage/events'}>
+                Zur Veranstaltungen-Übersicht
+            </BackButton>
+            <EditEvent
+                event={{
+                    ...event,
+                    attachments,
+                }}
+            />
+        </>
+    )
 }
 
 export default EditEventPage

--- a/frontend/src/app/(shell)/manage/events/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/events/[id]/page.tsx
@@ -1,5 +1,8 @@
 import {EditEvent} from '@/features/posts/components/EditEvent'
 import {eventApi} from '@/lib/api/api'
+import { Button } from '@/lib/components/common/Button'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
 
 interface EditEventPageProps {
     params: {
@@ -12,14 +15,26 @@ const EditEventPage = async ({ params }: EditEventPageProps) => {
     const files = await eventApi.eventUploadList({ id: params.id })
     const attachments = files.filter((file) => file.type === 'attachment')
 
-    return (
+    return (<>
+        <Button
+            asChild
+            size="sm"
+            variant="link"
+        >
+            <Link href="/manage/events">
+                <ArrowLeft />
+                <span className="ml-1">
+                    Zurück zu allen Veranstaltungen
+                </span>
+            </Link>
+        </Button>
         <EditEvent
             event={{
                 ...event,
                 attachments,
             }}
         />
-    )
+    </>)
 }
 
 export default EditEventPage

--- a/frontend/src/app/(shell)/manage/news/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/news/[id]/page.tsx
@@ -1,5 +1,8 @@
 import {EditNews} from '@/features/posts/components/EditNews'
 import {newsApi} from '@/lib/api/api'
+import { Button } from '@/lib/components/common/Button'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
 
 interface EditNewsPageProps {
     params: {
@@ -13,8 +16,21 @@ const EditNewsPage = async (props: EditNewsPageProps) => {
     const headerImage = files.find((file) => file.type === 'header')
     const attachments = files.filter((file) => file.type === 'attachment')
 
-    return (
+    return (<>
+        <Button
+            asChild
+            size="sm"
+            variant="link"
+        >
+            <Link href="/manage/news">
+                <ArrowLeft />
+                <span className="ml-1">
+                    Zurück zu allen Neuigkeiten
+                </span>
+            </Link>
+        </Button>
+
         <EditNews news={{...news, headerImage, attachments}} />
-    )
+    </>)
 }
 export default EditNewsPage

--- a/frontend/src/app/(shell)/manage/news/[id]/page.tsx
+++ b/frontend/src/app/(shell)/manage/news/[id]/page.tsx
@@ -1,8 +1,6 @@
 import {EditNews} from '@/features/posts/components/EditNews'
 import {newsApi} from '@/lib/api/api'
-import { Button } from '@/lib/components/common/Button'
-import { ArrowLeft } from 'lucide-react'
-import Link from 'next/link'
+import {BackButton} from '@/shared/components/BackButton'
 
 interface EditNewsPageProps {
     params: {
@@ -17,19 +15,7 @@ const EditNewsPage = async (props: EditNewsPageProps) => {
     const attachments = files.filter((file) => file.type === 'attachment')
 
     return (<>
-        <Button
-            asChild
-            size="sm"
-            variant="link"
-        >
-            <Link href="/manage/news">
-                <ArrowLeft />
-                <span className="ml-1">
-                    Zurück zu allen Neuigkeiten
-                </span>
-            </Link>
-        </Button>
-
+        <BackButton href={'/manage/news'}>Zur Neuigkeiten-Übersicht</BackButton>
         <EditNews news={{...news, headerImage, attachments}} />
     </>)
 }

--- a/frontend/src/app/(shell)/news/[id]/page.tsx
+++ b/frontend/src/app/(shell)/news/[id]/page.tsx
@@ -1,9 +1,7 @@
 import {NewsDetails} from '@/features/posts/components/NewsDetails'
 import {newsApi} from '@/lib/api/api'
 import {AttachmentResource, NewsResource} from '@/lib/api/generated'
-import { Button } from '@/lib/components/common/Button'
-import { ArrowLeft } from 'lucide-react'
-import Link from 'next/link'
+import {BackButton} from '@/shared/components/BackButton'
 
 interface Props {
     params: {
@@ -36,25 +34,14 @@ const SingleNewsPage = async (props: Props) => {
         )
     }
 
-    return (<>
-        <div className='mx-auto h-full max-w-[800px]'>
-            <Button
-                asChild
-                size="sm"
-                variant="link"
-                className='mb-4'
-            >
-                <Link href="/news">
-                    <ArrowLeft />
-                    <span className="ml-1">
-                        Zurück zu allen Neuigkeiten
-                    </span>
-                </Link>
-            </Button>
-
-            <NewsDetails news={{...news, headerImage, attachments}} />
-        </div>
-    </>)
+    return (
+        <>
+            <BackButton href={'/news'}>Zur Neuigkeiten-Übersicht</BackButton>
+            <div className='mx-auto h-full max-w-[800px]'>
+                <NewsDetails news={{...news, headerImage, attachments}} />
+            </div>
+        </>
+    )
 }
 
 export default SingleNewsPage

--- a/frontend/src/app/(shell)/news/[id]/page.tsx
+++ b/frontend/src/app/(shell)/news/[id]/page.tsx
@@ -1,6 +1,9 @@
 import {NewsDetails} from '@/features/posts/components/NewsDetails'
 import {newsApi} from '@/lib/api/api'
 import {AttachmentResource, NewsResource} from '@/lib/api/generated'
+import { Button } from '@/lib/components/common/Button'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
 
 interface Props {
     params: {
@@ -33,9 +36,25 @@ const SingleNewsPage = async (props: Props) => {
         )
     }
 
-    return (
-        <NewsDetails news={{...news, headerImage, attachments}} />
-    )
+    return (<>
+        <div className='mx-auto h-full max-w-[800px]'>
+            <Button
+                asChild
+                size="sm"
+                variant="link"
+                className='mb-4'
+            >
+                <Link href="/news">
+                    <ArrowLeft />
+                    <span className="ml-1">
+                        Zurück zu allen Neuigkeiten
+                    </span>
+                </Link>
+            </Button>
+
+            <NewsDetails news={{...news, headerImage, attachments}} />
+        </div>
+    </>)
 }
 
 export default SingleNewsPage

--- a/frontend/src/core/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/core/layout/Sidebar/Sidebar.tsx
@@ -43,6 +43,7 @@ export const Sidebar = async () => {
             label: t('manage'),
             hidden: !isCreator(sessionData),
             items: [
+                { title: 'Übersicht', url: '/manage' },
                 { title: 'Neuigkeiten', url: '/manage/news' },
                 { title: 'Veranstaltungen', url: '/manage/events' },
                 {

--- a/frontend/src/features/posts/components/EventDetails/EventDetails.tsx
+++ b/frontend/src/features/posts/components/EventDetails/EventDetails.tsx
@@ -8,39 +8,37 @@ interface EventDetailsProps {
 }
 
 const EventDetails = async ({event}: EventDetailsProps) => {
-    return (
-        <div className="mx-auto h-full max-w-[800px]">
-            <EventDetailsHeader event={event} />
-            <EventDetailsInfo event={event} />
-            <SanitizedHTMLContent
-                content={event.content}
-                allowedTags={[
-                    'p',
-                    'strong',
-                    'em',
-                    'a',
-                    'ul',
-                    'ol',
-                    'li',
-                    'img',
-                ]}
-            />
-            {event.linkedNews && event.linkedNews?.length > 0 ? (
-                <>
-                    <hr className="my-6" />
-                    <LinkedNews news={event.linkedNews} />
-                </>
-            ) : null}
-            {(event.attachments?.length ?? 0) > 0 ? (
-                <>
-                    <hr className="my-6" />
-                    <FileListPreview
-                        display='grid'
-                        files={event.attachments?.map((file) => file.data) ?? []}
-                        download /></>
-            ) : null}
-        </div>
-    )
+    return (<>
+        <EventDetailsHeader event={event} />
+        <EventDetailsInfo event={event} />
+        <SanitizedHTMLContent
+            content={event.content}
+            allowedTags={[
+                'p',
+                'strong',
+                'em',
+                'a',
+                'ul',
+                'ol',
+                'li',
+                'img',
+            ]}
+        />
+        {event.linkedNews && event.linkedNews?.length > 0 ? (
+            <>
+                <hr className="my-6" />
+                <LinkedNews news={event.linkedNews} />
+            </>
+        ) : null}
+        {(event.attachments?.length ?? 0) > 0 ? (
+            <>
+                <hr className="my-6" />
+                <FileListPreview
+                    display='grid'
+                    files={event.attachments?.map((file) => file.data) ?? []}
+                    download /></>
+        ) : null}
+    </>)
 }
 
 export { EventDetails }

--- a/frontend/src/features/posts/components/EventDetails/EventDetails.tsx
+++ b/frontend/src/features/posts/components/EventDetails/EventDetails.tsx
@@ -9,7 +9,7 @@ interface EventDetailsProps {
 
 const EventDetails = async ({event}: EventDetailsProps) => {
     return (
-        <div className='mx-auto h-full max-w-[800px]'>
+        <div className="mx-auto h-full max-w-[800px]">
             <EventDetailsHeader event={event} />
             <EventDetailsInfo event={event} />
             <SanitizedHTMLContent
@@ -39,7 +39,8 @@ const EventDetails = async ({event}: EventDetailsProps) => {
                         files={event.attachments?.map((file) => file.data) ?? []}
                         download /></>
             ) : null}
-        </div>)
+        </div>
+    )
 }
 
 export { EventDetails }

--- a/frontend/src/features/posts/components/EventDetails/EventDetails.tsx
+++ b/frontend/src/features/posts/components/EventDetails/EventDetails.tsx
@@ -8,37 +8,38 @@ interface EventDetailsProps {
 }
 
 const EventDetails = async ({event}: EventDetailsProps) => {
-    return (<>
-        <EventDetailsHeader event={event} />
-        <EventDetailsInfo event={event} />
-        <SanitizedHTMLContent
-            content={event.content}
-            allowedTags={[
-                'p',
-                'strong',
-                'em',
-                'a',
-                'ul',
-                'ol',
-                'li',
-                'img',
-            ]}
-        />
-        {event.linkedNews && event.linkedNews?.length > 0 ? (
-            <>
-                <hr className="my-6" />
-                <LinkedNews news={event.linkedNews} />
-            </>
-        ) : null}
-        {(event.attachments?.length ?? 0) > 0 ? (
-            <>
-                <hr className="my-6" />
-                <FileListPreview
-                    display='grid'
-                    files={event.attachments?.map((file) => file.data) ?? []}
-                    download /></>
-        ) : null}
-    </>)
+    return (
+        <div className='mx-auto h-full max-w-[800px]'>
+            <EventDetailsHeader event={event} />
+            <EventDetailsInfo event={event} />
+            <SanitizedHTMLContent
+                content={event.content}
+                allowedTags={[
+                    'p',
+                    'strong',
+                    'em',
+                    'a',
+                    'ul',
+                    'ol',
+                    'li',
+                    'img',
+                ]}
+            />
+            {event.linkedNews && event.linkedNews?.length > 0 ? (
+                <>
+                    <hr className="my-6" />
+                    <LinkedNews news={event.linkedNews} />
+                </>
+            ) : null}
+            {(event.attachments?.length ?? 0) > 0 ? (
+                <>
+                    <hr className="my-6" />
+                    <FileListPreview
+                        display='grid'
+                        files={event.attachments?.map((file) => file.data) ?? []}
+                        download /></>
+            ) : null}
+        </div>)
 }
 
 export { EventDetails }

--- a/frontend/src/shared/components/BackButton.tsx
+++ b/frontend/src/shared/components/BackButton.tsx
@@ -1,0 +1,22 @@
+import {Button} from '@/lib/components/common/Button'
+import {ChevronLeftIcon} from 'lucide-react'
+import Link from 'next/link'
+import React from 'react'
+
+interface BackButtonProps {
+    href: string;
+    children: React.ReactNode;
+}
+
+export const BackButton = ({href, children}: BackButtonProps) => {
+    return (
+        <Button asChild variant={'ghost'} size={'sm'} className={'h-6'}>
+            <Link href={href}>
+                <ChevronLeftIcon />
+                <span className="ml-1">
+                    {children}
+                </span>
+            </Link>
+        </Button>
+    )
+}

--- a/frontend/src/shared/components/BackButton.tsx
+++ b/frontend/src/shared/components/BackButton.tsx
@@ -12,10 +12,8 @@ export const BackButton = ({href, children}: BackButtonProps) => {
     return (
         <Button asChild variant={'ghost'} size={'sm'} className={'h-6'}>
             <Link href={href}>
-                <ChevronLeftIcon />
-                <span className="ml-1">
-                    {children}
-                </span>
+                <ChevronLeftIcon className={'mr-1'} />
+                {children}
             </Link>
         </Button>
     )


### PR DESCRIPTION
Fügt auf den Detailseiten von News und Events einen Zurückbutton ein, um die Navigation intuitiver zu gestalten.